### PR TITLE
display original logo size

### DIFF
--- a/src/components/degreeCard/DegreeCard.js
+++ b/src/components/degreeCard/DegreeCard.js
@@ -14,7 +14,6 @@ class DegreeCard extends Component {
               style={{
                 maxWidth: "100%",
                 maxHeight: "100%",
-                transform: "scale(50%, 50%)",
               }}
               src={require(`../../assests/images/${degree.logo_path}`)}
               alt={degree.alt_name}


### PR DESCRIPTION
It looks more better and visual.
from this:
![Screenshot (171)](https://user-images.githubusercontent.com/40722235/89208612-4d054800-d5da-11ea-9144-601cb4581751.png)
to this:
![Screenshot (170)](https://user-images.githubusercontent.com/40722235/89208634-5a223700-d5da-11ea-95f8-2612b2e13da7.png)

Changes would be publicly visible on your domain when pushed for gh-pages.
