### PR TITLE
token vulnerability fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ You can get a github token as described [here](https://docs.github.com/en/github
 Now, you need to run following command.
 
 ```python
+npm install dotenv --save
 node git_data_fetcher.js
 ```
 

--- a/README.md
+++ b/README.md
@@ -90,14 +90,31 @@ You can change the personal information, experience, education, social media, ce
 
 ### Github Information
 
+
 You will find `git_data_fetcher.js` file in the main directory of the repository. This file is used to fetch the data (Pull requests, Issues, Organizations, Pinned projects etc.) from your github.
 If you open the file, you will see below component at the top of the file. You need to change only that component.
 
-```python
-const openSource = {
-  githubConvertedToken: "Your Github Token Here.",
-  githubUserName: "Your Github Username Here.",
-};
+1. Create a file called .env in the root directory of your project, check the base file
+
+Note: Instead of creating a .env file, you can just run this command "cp env.example .env" inside the root directory
+
+```bash
+- masterportFolio
+  - node_modules
+  - public
+  - src
+  - .env         <-- create it here
+  - env.example  <-- this is the base file
+  - .gitignore
+  - package-lock.json
+  - package.json
+```
+
+2. Inside the .env file, add key `REACT_APP_GITHUB_TOKEN` and assign your github token like this.
+
+```javascript
+ // .env
+  REACT_APP_GITHUB_TOKEN = "YOUR GITHUB TOKEN HERE"
 ```
 
 You can get a github token as described [here](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token). Give all permissions while generating token. Also add your `githubUserName` in the correct field inside `git_data_fetcher.js`.

--- a/env.example
+++ b/env.example
@@ -1,0 +1,7 @@
+// README
+// This is only a .env example
+// Do not change this file, adding your GITHUB TOKEN here!
+// Use cp or mv (like this: cp env.example .env), then edit .env with your GITHUB TOKEN.
+// IMPORTANT: Don't forget to add to update your .gitignore with .env (to avoid public share your key!)
+ 
+REACT_APP_GITHUB_TOKEN = "YOUR GITHUB TOKEN HERE"

--- a/git_data_fetcher.js
+++ b/git_data_fetcher.js
@@ -1,3 +1,5 @@
+require('dotenv').config();
+
 const openSource = {
   githubConvertedToken: process.env.REACT_APP_GITHUB_TOKEN,
   githubUserName: "Your Github Username Here.",

--- a/git_data_fetcher.js
+++ b/git_data_fetcher.js
@@ -1,5 +1,5 @@
 const openSource = {
-  githubConvertedToken: "Your Github Token Here.",
+  githubConvertedToken: process.env.REACT_APP_GITHUB_TOKEN,
   githubUserName: "Your Github Username Here.",
 };
 


### PR DESCRIPTION
Used a `.env` file to store the github token and then called the variable in `git_data_fetcher.js` instead of directly putting the token here, which would have exposed it to the public. 

![image](https://user-images.githubusercontent.com/42533823/93562593-23488a80-f9a8-11ea-9db7-7c5eb7184d51.png)

![image](https://user-images.githubusercontent.com/42533823/93562503-f72d0980-f9a7-11ea-9f8e-eba945c6a4ea.png)

`.env` has been added to the `.gitignore` .

Also changed the `README.md` to add new process for creating `.env` file from the `env.example` file provided.

![image](https://user-images.githubusercontent.com/42533823/93562406-cf3da600-f9a7-11ea-871f-41599b03b2c9.png)
