### PR TITLE
project card name height fix

### DIFF
--- a/src/components/githubRepoCard/GithubRepoCard.css
+++ b/src/components/githubRepoCard/GithubRepoCard.css
@@ -58,6 +58,7 @@
   font-weight: 700;
   letter-spacing: -0.5px;
   overflow: hidden;
+  line-height: 1.2;
   margin: 0px;
 }
 
@@ -72,6 +73,7 @@
   font-family: "Google Sans Regular";
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
+  margin-top: 0.8rem;
 }
 
 .repo-details {


### PR DESCRIPTION
Changes added in `GithubRepoCard.css` :
Added `line-height: 1.2` to `.repo-name` and reduced the margin to `margin-top: 0.8rem` for `.repo-description` to compensate the height increase.

Before:
![image](https://user-images.githubusercontent.com/42533823/93781049-c28cac80-fc4a-11ea-9f0c-fd1abf03eb71.png)

After:
![image](https://user-images.githubusercontent.com/42533823/93781151-e2bc6b80-fc4a-11ea-9bda-0c1742f0b20e.png)
