### PR TITLE
This fix's horizontal scroll on open-source page as per issue #124

### DIFF
--- a/src/containers/opensourceCharts/OpensourceCharts.css
+++ b/src/containers/opensourceCharts/OpensourceCharts.css
@@ -19,6 +19,12 @@
     display: table-cell;
 } */
 
+/* To remove horizontal scroll */
+.main-div {
+  width: 90%;
+  margin: 0 auto;
+}
+
 @media (max-width: 1380px) {
   .os-charts-header {
     font-size: 35px;

--- a/src/containers/opensourceCharts/OpensourceCharts.js
+++ b/src/containers/opensourceCharts/OpensourceCharts.js
@@ -8,7 +8,7 @@ class OpensourceCharts extends Component {
   render() {
     const theme = this.props.theme;
     return (
-      <div>
+      <div className="main-div">
         <div className="os-charts-header-div">
           <Fade bottom duration={2000} distance="20px">
             <h1 className="os-charts-header" style={{ color: theme.text }}>

--- a/src/index.css
+++ b/src/index.css
@@ -47,6 +47,7 @@ code {
 html,
 body {
   scroll-behavior: smooth;
+  overflow-x: hidden;
 }
 body {
   margin: 0;


### PR DESCRIPTION
There was a horizontal scroll on the "Open Source" page in mobile view.  Fixed issue #124 