### PR TITLE
Checks on Education Page

### DIFF
--- a/src/components/degreeCard/DegreeCard.css
+++ b/src/components/degreeCard/DegreeCard.css
@@ -59,7 +59,7 @@
   max-width: inherit;
   /* width: 100%; */
   border-radius: 0px 0px 7px 7px;
-  padding: 5px;
+  padding: 10px;
   justify-content: center;
   align-items: center;
   /* box-shadow: 5px 5px 5px #d3d3d3; */
@@ -77,7 +77,6 @@
   border-left: 1px solid #d9dbdf;
   border-right: 1px solid #d9dbdf;
   border-radius: 7px;
-  width: 90%;
   margin: 10px;
   box-shadow: 5px 5px 5px #d9dbdf;
 }
@@ -136,7 +135,7 @@
   }
 
   .card-body {
-    width: 100%;
+    width: 100% !important;
   }
 
   .card-title {

--- a/src/components/degreeCard/DegreeCard.js
+++ b/src/components/degreeCard/DegreeCard.js
@@ -8,21 +8,26 @@ class DegreeCard extends Component {
     const theme = this.props.theme;
     return (
       <div className="degree-card">
-        <Flip left duration={2000}>
-          <div className="card-img">
-            <img
-              style={{
-                maxWidth: "100%",
-                maxHeight: "100%",
-                transform: "scale(0.9)",
-              }}
-              src={require(`../../assests/images/${degree.logo_path}`)}
-              alt={degree.alt_name}
-            />
-          </div>
-        </Flip>
+        {degree.logo_path && (
+          <Flip left duration={2000}>
+            <div className="card-img">
+              <img
+                style={{
+                  maxWidth: "100%",
+                  maxHeight: "100%",
+                  transform: "scale(0.9)",
+                }}
+                src={require(`../../assests/images/${degree.logo_path}`)}
+                alt={degree.alt_name}
+              />
+            </div>
+          </Flip>
+        )}
         <Fade right duration={2000} distance="40px">
-          <div className="card-body">
+          <div
+            className="card-body"
+            style={{ width: degree.logo_path ? "90%" : "100%" }}
+          >
             <div
               className="body-header"
               style={{ backgroundColor: theme.headerColor }}
@@ -41,7 +46,7 @@ class DegreeCard extends Component {
                 </h3>
               </div>
             </div>
-            <div classname="body-content">
+            <div className="body-content">
               {degree.descriptions.map((sentence) => {
                 return (
                   <p className="content-list" style={{ color: theme.text }}>
@@ -49,20 +54,22 @@ class DegreeCard extends Component {
                   </p>
                 );
               })}
-              <a
-                href={degree.website_link}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <div
-                  className="visit-btn"
-                  style={{ backgroundColor: theme.headerColor }}
+              {degree.website_link && (
+                <a
+                  href={degree.website_link}
+                  target="_blank"
+                  rel="noopener noreferrer"
                 >
-                  <p className="btn" style={{ color: theme.text }}>
-                    Visit Website
-                  </p>
-                </div>
-              </a>
+                  <div
+                    className="visit-btn"
+                    style={{ backgroundColor: theme.headerColor }}
+                  >
+                    <p className="btn" style={{ color: theme.text }}>
+                      Visit Website
+                    </p>
+                  </div>
+                </a>
+              )}
             </div>
           </div>
         </Fade>


### PR DESCRIPTION
Added checks for logo and visit website button on education card. Issue #195 

### Reason
Users might want to add school and junior college information which might not have logo and website

### Changes
**Logo**
1. Added check for logo. Logo would be rendered only if the logo is given.
2. Shifted the width property from CSS to inline so that we can have 100% width for the card if there is no logo.

**Button**
1. Added check for URL. Button would appear only if URL is given
2. Increased padding so that it looks fine even if there is no button.

### Testing
1. Tested the changes thoroughly on all screen sizes. 

**Note:** I am aware that using `!important` is not a good practice but had to use it in media query as that's the only way to set width to 100% on mobile device in this implementation and i think it doesn't create any problem here.

### Screenshot

![image](https://user-images.githubusercontent.com/40917760/169661274-e878126d-7690-45c3-a7d8-c94855663e1f.png)

