### PR TITLE
Added onlick for organization icons and limit in github data fetcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ node git_data_fetcher.mjs
 ```
 
 This will fetch all the data from your github and it will automatically replace my data with yours.
-Whenever you want to update the github related information on the website you need to run this command.
+Whenever you want to update the github related information on the website you need to run this command. The default limit is 100. This means only last 100 issues and pull requests will be shown (if available). But you can increase this by adding arguments. `--pr-limit(-pl)` for pull requests, `--issue-limit(-il)` for issues, `--org-limit(-ol)` for organizations and `--limit(-l)` for all. Example: `node git_data_fetcher.mjs -l 200` Keep in mind that adding a huge data may affect website perfomance.
 
 ### Splash Logo
 

--- a/git_data_fetcher.mjs
+++ b/git_data_fetcher.mjs
@@ -6,122 +6,167 @@ const openSource = {
   githubUserName: "Your Github Username Here",
 };
 
-const query_pr = {
+const numify = (number) => Number.isInteger(parseInt(number)) ? parseInt(number) : 100
+
+const argArray = process.argv.slice(2);
+const args = {}
+argArray.forEach((arg, i) => {
+  if (arg.startsWith('-')) {
+     args[arg.toLowerCase().replace(/^(--|-)/, "")] = argArray[i+1]?.startsWith("-") ? true : argArray[i+1] || true;
+    }
+})
+
+const limit = numify(args.limit || args.l);
+const pr_limit = numify(args["pr-limit"] || args.pl || limit);
+const issue_limit = numify(args["issue-limit"] || args.il || limit);
+const org_limit = numify(args["org-limit"] || args.ol || limit);
+
+
+const query_pr = (cursor) => ({
   query: `
-	query {
-	  user(login: "${openSource.githubUserName}"){
-	    pullRequests(last: 100, orderBy: {field: CREATED_AT, direction: DESC}){
-      totalCount
-      nodes{
-        id
-        title
-        url
-        state
-	      mergedBy {
-	          avatarUrl
-	          url
-	          login
-	      }
-	      createdAt
-	      number
-        changedFiles
-	      additions
-	      deletions
-        baseRepository {
-	          name
-	          url
-	          owner {
-	            avatarUrl
-	            login
-	            url
-	          }
-	        }
-      }
-    }
-	}
-}
-	`,
-};
-
-const query_issue = {
-  query: `query{
-
-		user(login: "${openSource.githubUserName}") {
-    issues(last: 100, orderBy: {field:CREATED_AT, direction: DESC}){
-      totalCount
-      nodes{
-      	id
-        closed
-        title
-        createdAt
-        url
-        number
-        assignees(first:100){
+    query {
+      user(login: "${openSource.githubUserName}"){
+        pullRequests(
+          last: 100, 
+          ${cursor && `before: "${cursor}"`}
+          orderBy: {
+            field: CREATED_AT, 
+            direction: DESC
+          }){
+          totalCount
           nodes{
-            avatarUrl
-            name
+            id
+            title
             url
+            state
+            mergedBy {
+              avatarUrl
+              url
+              login
+            }
+            createdAt
+            number
+            changedFiles
+            additions
+            deletions
+            baseRepository {
+              name
+              url
+              owner {
+                avatarUrl
+                login
+                url
+              }
+            }
           }
-        }
-        repository{
-          name
-          url
-          owner{
-            login
-            avatarUrl
-            url
+          pageInfo {
+            startCursor
           }
         }
       }
     }
-  }
+  `,
+})
 
-	}`,
-};
+const query_issue = (cursor) => ({
+  query: `
+    query{
+      user(login: "${openSource.githubUserName}") {
+        issues(
+          last: 100,
+          ${cursor && `before: "${cursor}"`}
+          orderBy: {
+            field:CREATED_AT, 
+            direction: DESC
+          }){
+          totalCount
+          nodes{
+            id
+            closed
+            title
+            createdAt
+            url
+            number
+            assignees(first:100){
+              nodes{
+                avatarUrl
+                name
+                url
+              }
+            }
+            repository{
+              name
+              url
+              owner{
+                login
+                avatarUrl
+                url
+              }
+            }
+          }
+          pageInfo {
+            startCursor
+          }
+        }
+      }
+    }
+  `,
+})
 
-const query_org = {
+const query_org = (cursor) => ({
   query: `query{
-	user(login: "${openSource.githubUserName}") {
-	    repositoriesContributedTo(last: 100){
-	      totalCount
-	      nodes{
-	        owner{
-	          login
-	          avatarUrl
-	          __typename
-	        }
-	      }
-	    }
-	  }
-	}`,
-};
+    user(login: "${openSource.githubUserName}") {
+        repositoriesContributedTo(
+          last: 100,
+          ${cursor && `before: "${cursor}"`}
+          ){
+          totalCount
+          nodes{
+            owner{
+              url
+              login
+              avatarUrl
+              __typename
+            }
+          }
+          pageInfo {
+            startCursor
+          }
+        }
+      }
+    }
+  `,
+})
 
 const query_pinned_projects = {
   query: `
-	query { 
-	  user(login: "${openSource.githubUserName}") { 
-	    pinnedItems(first: 6, types: REPOSITORY) {
-	      totalCount
-	      nodes{
-	        ... on Repository{
-	          id
-		          name
-		          createdAt,
-		          url,
-		          description,
-		          isFork,
-		          languages(first:10){
-		            nodes{
-		              name
-		            }
-		          }
-	        }
-	      }
-		  }
-	  }
-	}
-	`,
-};
+    query { 
+      user(login: "${openSource.githubUserName}") { 
+        pinnedItems(
+          first: 6, 
+          types: REPOSITORY
+          ) {
+          totalCount
+          nodes{
+            ... on Repository{
+              id
+              name
+              createdAt
+              url
+              description
+              isFork
+              languages(first:10){
+                nodes{
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `,
+}
 
 const baseUrl = "https://api.github.com/graphql";
 
@@ -130,21 +175,36 @@ const headers = {
   Authorization: "bearer " + openSource.githubConvertedToken,
 };
 
-fetch(baseUrl, {
+const getOptions = (cursor, query) => ({
   method: "POST",
-  headers: headers,
-  body: JSON.stringify(query_pr),
+  headers: {
+    "Content-Type": "application/json",
+     Authorization: "bearer " + openSource.githubConvertedToken,
+  },
+  body: JSON.stringify(query(cursor)),
 })
-  .then((response) => response.text())
-  .then((txt) => {
-    const data = JSON.parse(txt);
-    var cropped = { data: [] };
-    cropped["data"] = data["data"]["user"]["pullRequests"]["nodes"];
 
-    var open = 0;
-    var closed = 0;
-    var merged = 0;
-    for (var i = 0; i < cropped["data"].length; i++) {
+fetch(baseUrl, getOptions("", query_pr))
+  .then((res) => res.json())
+  .then(async(response) => {
+    const data = { data: response.data }
+    let cursor = response["data"]["user"]["pullRequests"]["pageInfo"]["startCursor"];
+    while (response["data"]["user"]["pullRequests"]["nodes"].length === 100) {
+        if (response["data"]["user"]["pullRequests"]["nodes"].length >= pr_limit) break
+        const options = getOptions(cursor, query_pr);
+        const resp = await fetch(baseUrl, options);
+        response = await resp.json();
+        let currentPullRequests = response["data"]["user"]["pullRequests"];
+        data["data"]["user"]["pullRequests"]["nodes"] = [...currentPullRequests["nodes"], ...data["data"]["user"]["pullRequests"]["nodes"]];
+        cursor = currentPullRequests["pageInfo"]["startCursor"];
+    }
+    const cropped = { data: [] };
+    cropped["data"] = data["data"]["user"]["pullRequests"]["nodes"];
+    
+    let open = 0;
+    let closed = 0;
+    let merged = 0;
+    for (let i = 0; i < cropped["data"].length; i++) {
       if (cropped["data"][i]["state"] === "OPEN") open++;
       else if (cropped["data"][i]["state"] === "MERGED") merged++;
       else closed++;
@@ -155,7 +215,7 @@ fetch(baseUrl, {
     cropped["merged"] = merged;
     cropped["totalCount"] = cropped["data"].length;
 
-    console.log("Fetching the Pull Request Data.\n");
+    console.log("Fetching Pull Requests Data.\n");
     fs.writeFile(
       "./src/shared/opensource/pull_requests.json",
       JSON.stringify(cropped),
@@ -168,20 +228,26 @@ fetch(baseUrl, {
   })
   .catch((error) => console.log(JSON.stringify(error)));
 
-fetch(baseUrl, {
-  method: "POST",
-  headers: headers,
-  body: JSON.stringify(query_issue),
-})
-  .then((response) => response.text())
-  .then((txt) => {
-    const data = JSON.parse(txt);
-    var cropped = { data: [] };
+fetch(baseUrl, getOptions("", query_issue))
+  .then((res) => res.json())
+  .then(async(response) => {
+    const data = { data: response.data }
+    let cursor = response["data"]["user"]["issues"]["pageInfo"]["startCursor"];
+    while (response["data"]["user"]["issues"]["nodes"].length === 100) {
+        if (response["data"]["user"]["issues"]["nodes"].length >= issue_limit) break
+        const options = getOptions(cursor, query_issue);
+        const resp = await fetch(baseUrl, options);
+        response = await resp.json();
+        let currentIssues = response["data"]["user"]["issues"];
+        data["data"]["user"]["issues"]["nodes"] = [...currentIssues["nodes"], ...data["data"]["user"]["issues"]["nodes"]];
+        cursor = currentIssues["pageInfo"]["startCursor"];
+    }
+    const cropped = { data: [] };
     cropped["data"] = data["data"]["user"]["issues"]["nodes"];
 
-    var open = 0;
-    var closed = 0;
-    for (var i = 0; i < cropped["data"].length; i++) {
+    let open = 0;
+    let closed = 0;
+    for (let i = 0; i < cropped["data"].length; i++) {
       if (cropped["data"][i]["closed"] === false) open++;
       else closed++;
     }
@@ -190,7 +256,7 @@ fetch(baseUrl, {
     cropped["closed"] = closed;
     cropped["totalCount"] = cropped["data"].length;
 
-    console.log("Fetching the Issues Data.\n");
+    console.log("Fetching Issues Data.\n");
     fs.writeFile(
       "./src/shared/opensource/issues.json",
       JSON.stringify(cropped),
@@ -203,21 +269,28 @@ fetch(baseUrl, {
   })
   .catch((error) => console.log(JSON.stringify(error)));
 
-fetch(baseUrl, {
-  method: "POST",
-  headers: headers,
-  body: JSON.stringify(query_org),
-})
-  .then((response) => response.text())
-  .then((txt) => {
-    const data = JSON.parse(txt);
+fetch(baseUrl, getOptions("", query_org))
+  .then((res) => res.json())
+  .then(async(response) => {
+    const data = { data: response.data }
+    let cursor = response["data"]["user"]["repositoriesContributedTo"]["pageInfo"]["startCursor"];
+    while (response["data"]["user"]["repositoriesContributedTo"]["nodes"].length === 100) {
+        if (response["data"]["user"]["repositoriesContributedTo"]["nodes"].length >= org_limit) break
+        const options = getOptions(cursor, query_org);
+        const resp = await fetch(baseUrl, options);
+        response = await resp.json();
+        let currentContributedTo = response["data"]["user"]["repositoriesContributedTo"];
+        data["data"]["user"]["repositoriesContributedTo"]["nodes"] = [...currentContributedTo["nodes"], ...data["data"]["user"]["repositoriesContributedTo"]["nodes"]];
+        cursor = currentContributedTo["pageInfo"]["startCursor"];
+    }
     const orgs = data["data"]["user"]["repositoriesContributedTo"]["nodes"];
-    var newOrgs = { data: [] };
-    for (var i = 0; i < orgs.length; i++) {
-      var obj = orgs[i]["owner"];
+    
+    let newOrgs = { data: [] };
+    for (let i = 0; i < orgs.length; i++) {
+      let obj = orgs[i]["owner"];
       if (obj["__typename"] === "Organization") {
-        var flag = 0;
-        for (var j = 0; j < newOrgs["data"].length; j++) {
+        let flag = 0;
+        for (let j = 0; j < newOrgs["data"].length; j++) {
           if (JSON.stringify(obj) === JSON.stringify(newOrgs["data"][j])) {
             flag = 1;
             break;
@@ -229,7 +302,7 @@ fetch(baseUrl, {
       }
     }
 
-    console.log("Fetching the Contributed Organization Data.\n");
+    console.log("Fetching Contributed Organizations Data.\n");
     fs.writeFile(
       "./src/shared/opensource/organizations.json",
       JSON.stringify(newOrgs),
@@ -262,17 +335,15 @@ fetch(baseUrl, {
   headers: headers,
   body: JSON.stringify(query_pinned_projects),
 })
-  .then((response) => response.text())
-  .then((txt) => {
-    const data = JSON.parse(txt);
-    // console.log(txt);
+  .then((res) => res.json())
+  .then((data) => {  
     const projects = data["data"]["user"]["pinnedItems"]["nodes"];
-    var newProjects = { data: [] };
-    for (var i = 0; i < projects.length; i++) {
-      var obj = projects[i];
-      var langobjs = obj["languages"]["nodes"];
-      var newLangobjs = [];
-      for (var j = 0; j < langobjs.length; j++) {
+    let newProjects = { data: [] };
+    for (let i = 0; i < projects.length; i++) {
+      let obj = projects[i];
+      let langobjs = obj["languages"]["nodes"];
+      let newLangobjs = [];
+      for (let j = 0; j < langobjs.length; j++) {
         if (langobjs[j]["name"] in languages_icons) {
           newLangobjs.push({
             name: langobjs[j]["name"],
@@ -284,7 +355,7 @@ fetch(baseUrl, {
       newProjects["data"].push(obj);
     }
 
-    console.log("Fetching the Pinned Projects Data.\n");
+    console.log("Fetching Pinned Projects Data.\n");
     fs.writeFile(
       "./src/shared/opensource/projects.json",
       JSON.stringify(newProjects),

--- a/src/components/organizationList/OrganizationList.js
+++ b/src/components/organizationList/OrganizationList.js
@@ -1,14 +1,17 @@
-import React, { Component } from "react";
-import "./OrganizationList.css";
-import { OverlayTrigger, Tooltip } from "react-bootstrap";
+import React from "react";
 import { Fade } from "react-reveal";
+import { OverlayTrigger, Tooltip } from "react-bootstrap";
+import "./OrganizationList.css";
 
-class OrganizationList extends Component {
-  render() {
+const OrganizationList = (props) => {
+    const open= (url) => {
+      const win = window.open(url, "_blank");
+      win.focus();
+    }
     return (
       <div className="organizations-main-div">
         <ul className="dev-icons-orgs">
-          {this.props.logos.map((logo) => {
+          {props.logos.map((logo) => {
             return (
               <OverlayTrigger
                 key={logo["login"]}
@@ -24,6 +27,7 @@ class OrganizationList extends Component {
                   <Fade bottom duration={2000} distance="40px">
                     <img
                       className="organizations-img"
+                      onClick={()=>open(logo["url"])}
                       src={logo["avatarUrl"]}
                       alt={logo["login"]}
                     />
@@ -35,7 +39,6 @@ class OrganizationList extends Component {
         </ul>
       </div>
     );
-  }
 }
 
 export default OrganizationList;


### PR DESCRIPTION
### Summary of changes
 - Formatting queries(fixed indentation)
 - Added argument support in fetcher file to fetch more data (pull requests and issues more than 100 (upto given limit))
 - Added onclick for organization icons
 
### Details on fetcher
Now `git_data_fetcher.mjs` accepts four arguments. `--pr-limit(-pl)` for pull requests, `--issue-limit(-il)` for issues, `--org-limit(-ol)` for organizations and `--limit(-l)` for all. Example: `node git_data_fetcher.mjs -l 200`.Until the limit matches we keep requesting to github api and append the data altogether. So, user contributed organizations will properly appear now. 