### PR TITLE
Remove Node-Sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "gh-pages": "^2.1.1",
     "graphql": "^14.5.8",
     "node-fetch": "^2.6.0",
-    "node-sass": "^7.0.0",
     "prettier-package-json": "^2.1.3",
     "radium": "^0.26.0",
     "react": "^16.10.2",


### PR DESCRIPTION
Removed node-sass as it is not being used and also is causing a lot of incompatibility issues with various versions of Nodejs