### PR TITLE
Fixed missing display:flex to align heading imgs vertically and horizontally

### DIFF
--- a/src/pages/contact/ContactComponent.css
+++ b/src/pages/contact/ContactComponent.css
@@ -33,6 +33,7 @@
 }
 
 .contact-heading-img-div {
+  display: flex;
   align-items: center;
   justify-content: center;
 }

--- a/src/pages/contact/ContactComponent.css
+++ b/src/pages/contact/ContactComponent.css
@@ -33,7 +33,6 @@
 }
 
 .contact-heading-img-div {
-  display: flex;
   align-items: center;
   justify-content: center;
 }

--- a/src/pages/education/EducationComponent.css
+++ b/src/pages/education/EducationComponent.css
@@ -16,6 +16,7 @@
 }
 
 .heading-img-div {
+  display: flex;
   align-items: center;
   justify-content: center;
 }

--- a/src/pages/experience/Experience.css
+++ b/src/pages/experience/Experience.css
@@ -16,6 +16,7 @@
 }
 
 .experience-heading-img-div {
+  display: flex;
   align-items: center;
   justify-content: center;
 }

--- a/src/pages/projects/Projects.css
+++ b/src/pages/projects/Projects.css
@@ -17,6 +17,7 @@
 }
 
 .projects-heading-img-div {
+  display: flex;
   align-items: center;
   justify-content: center;
 }


### PR DESCRIPTION
I have found that in the CSS files:

-  _src/pages/contact/ContactComponent.css_
-  _src/pages/education/EducationComponent.css_
-  _src/pages/experience/Experience.css_ 
-  _src/pages/projects/Projects.css_,
 
on the CSS selectors 
- _**.contact-heading-img-div**_, 
- _**.heading-img-div**_, 
- _**.experience-heading-img-div**_  
- _**.projects-heading-img-div**_, 
 
respectively, it was lacking the _display: flex_ property for _the align-items: center_ and _justify-content: center_ properties to work.