### PR TITLE
feat: support both icon and image rendering for competitive sites

### DIFF
--- a/src/components/competitiveSites/CompetitiveSites.js
+++ b/src/components/competitiveSites/CompetitiveSites.js
@@ -25,12 +25,22 @@ class CompetitiveSites extends React.Component {
                     target="_blank"
                     rel="noopener noreferrer"
                   >
-                    <span
-                      className="iconify"
-                      data-icon={logo.iconifyClassname}
-                      style={logo.style}
-                      data-inline="false"
-                    ></span>
+                    {logo.iconifyClassname && (
+                      <span
+                        className="iconify"
+                        data-icon={logo.iconifyClassname}
+                        style={logo.style}
+                        data-inline="false"
+                      ></span>
+                    )}
+                    {!logo.iconifyClassname && logo.imageSrc && (
+                      <img
+                        className="skill-image"
+                        style={logo.style}
+                        src={`${process.env.PUBLIC_URL}/skills/${logo.imageSrc}`}
+                        alt={logo.siteName}
+                      />
+                    )}
                   </a>
                 </li>
               </OverlayTrigger>


### PR DESCRIPTION
Updated the CompetitiveSites component to support both icon-based and image-based rendering within the profile link.

- Added conditional logic to render either an icon (via iconifyClassname) or an image (via imageSrc).
- Ensured styling is applied consistently via logo.style.
- Maintained existing anchor tag structure with target and rel attributes for safe external linking.

This improves flexibility by allowing platforms without iconify support to use custom images.