### PR TITLE
Fixed: Horizontal overflow of "ExperienceCard" after expanding in Mobile

### DIFF
--- a/src/components/experienceCard/ExperienceCard.css
+++ b/src/components/experienceCard/ExperienceCard.css
@@ -88,7 +88,7 @@
 }
 
 .experience-card {
-  min-width: 350px;
+  min-width: 275px;
   /* height: 170px; */
   margin-bottom: 20px;
   border-radius:10px;


### PR DESCRIPTION
# What this PR does?
- This PR fixes the issue of overflowing of "ExperienceCard" after expanding it on Mobile view.
- It perfectly adjusts "ExperienceCard" and makes it responsive without affecting the current Desktop view.
- Below are the given images for visual explaination:

# ✔️CURRENT MOBILE VIEW:
![photo_2025-12-24_18-29-58](https://github.com/user-attachments/assets/96ae5b93-34f7-4363-8c1e-a60a59befd7b)

# ✅MY FIXES:
### Mobile View:
![photo_2025-12-24_18-30-08](https://github.com/user-attachments/assets/035a00f2-1fd1-4432-892a-11e75fe5486f)

### Desktop View:
<img width="1894" height="1005" alt="Screenshot 2025-12-24 170504" src="https://github.com/user-attachments/assets/8158e01b-7044-4381-ad20-0cd82011a35a" />

\
\
> ## If there is mistake by me, kindly please correct me. Thank You
